### PR TITLE
Fix builds

### DIFF
--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -11,17 +11,6 @@
  */
 error_reporting(E_ALL | E_STRICT);
 
-if (class_exists('PHPUnit_Runner_Version', true)) {
-    $phpUnitVersion = PHPUnit_Runner_Version::id();
-    if ('@package_version@' !== $phpUnitVersion && version_compare($phpUnitVersion, '4.0.0', '<')) {
-        echo 'This version of PHPUnit (' . PHPUnit_Runner_Version::id() . ') is not supported'
-           . ' in the laminas-test unit tests. Supported is version 4.0.0 or higher.'
-           . ' See also the CONTRIBUTING.md file in the component root.' . PHP_EOL;
-        exit(1);
-    }
-    unset($phpUnitVersion);
-}
-
 /**
  * Setup autoloading
  */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      |no
| New Feature   | no
| RFC           |no
| QA            | yes

### Description
Obsolete version check in `test/bootstrap.php` prevents tests from running on lowest dependencies