### PR TITLE
add type hints to docblock, add a verb to Exception message

### DIFF
--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -487,15 +487,15 @@ abstract class AbstractControllerTestCase extends TestCase
     /**
      * Assert the application exception and message
      *
-     * @param $type application exception type
-     * @param $message application exception message
+     * @param string $type application exception type
+     * @param string|null $message application exception message
      */
     public function assertApplicationException($type, $message = null)
     {
         $exception = $this->getApplication()->getMvcEvent()->getParam('exception');
         if (! $exception) {
             throw new ExpectationFailedException($this->createFailureMessage(
-                'Failed asserting application exception, exception not exist'
+                'Failed asserting application exception, param "exception" does not exist'
             ));
         }
         if (true === $this->traceError) {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Add missing type hints to `AbstractControllerTestCase::assertApplicationException()`.

This was PR https://github.com/zendframework/zend-test/pull/80 before migrating to Laminas.