### PR TITLE
Correction of the behavior to check a module name

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.7.3@38c452ae584467e939d55377aaf83b5a26f19dd1">
+  <file src="src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php">
+    <MixedArgument occurrences="5">
+      <code>$appModules</code>
+      <code>$appModules</code>
+      <code>$appModules</code>
+      <code>$appModules</code>
+      <code>$other</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$appModules</code>
+    </MixedAssignment>
+    <PossiblyFalseArgument occurrences="1">
+      <code>strrpos($appModules, '\\')</code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="src/PHPUnit/Constraint/LaminasConstraint.php">
+    <InternalClass occurrences="1"/>
+    <InternalMethod occurrences="1">
+      <code>getComparisonFailure</code>
+    </InternalMethod>
+    <MixedArgument occurrences="1">
+      <code>$controllerManager-&gt;get($controllerIdentifier)</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$controllerIdentifier</code>
+      <code>$controllerManager</code>
+      <code>$routeMatch</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="4">
+      <code>get</code>
+      <code>getParam</code>
+      <code>getParam</code>
+      <code>getRouteMatch</code>
+    </MixedMethodCall>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getMvcEvent</code>
+      <code>getMvcEvent</code>
+    </UndefinedInterfaceMethod>
+  </file>
   <file src="src/PHPUnit/Controller/AbstractConsoleControllerTestCase.php">
+    <DeprecatedMethod occurrences="2">
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+    </DeprecatedMethod>
     <InternalClass occurrences="2"/>
     <MixedArgument occurrences="5">
       <code>$response-&gt;getContent()</code>
@@ -14,7 +57,32 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$type</code>
     </ArgumentTypeCoercion>
-    <InternalClass occurrences="25">
+    <DeprecatedMethod occurrences="23">
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+    </DeprecatedMethod>
+    <InternalClass occurrences="23">
       <code>new ExpectationFailedException($this-&gt;createFailureMessage('No route matched'))</code>
       <code>new ExpectationFailedException($this-&gt;createFailureMessage('No route matched'))</code>
       <code>new ExpectationFailedException($this-&gt;createFailureMessage('No route matched'))</code>
@@ -29,49 +97,6 @@
     <MissingClosureParamType occurrences="1">
       <code>$r</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="1">
-      <code>function ($r) use ($event) {</code>
-    </MissingClosureReturnType>
-    <MissingConstructor occurrences="15">
-      <code>$application</code>
-      <code>$application</code>
-      <code>$application</code>
-      <code>$application</code>
-      <code>$application</code>
-      <code>$applicationConfig</code>
-      <code>$applicationConfig</code>
-      <code>$applicationConfig</code>
-      <code>$applicationConfig</code>
-      <code>$applicationConfig</code>
-      <code>$usedConsoleBackup</code>
-      <code>$usedConsoleBackup</code>
-      <code>$usedConsoleBackup</code>
-      <code>$usedConsoleBackup</code>
-      <code>$usedConsoleBackup</code>
-    </MissingConstructor>
-    <MissingReturnType occurrences="21">
-      <code>assertActionName</code>
-      <code>assertApplicationException</code>
-      <code>assertControllerClass</code>
-      <code>assertControllerName</code>
-      <code>assertMatchedRouteName</code>
-      <code>assertModuleName</code>
-      <code>assertModulesLoaded</code>
-      <code>assertNoMatchedRoute</code>
-      <code>assertNotActionName</code>
-      <code>assertNotControllerClass</code>
-      <code>assertNotControllerName</code>
-      <code>assertNotMatchedRouteName</code>
-      <code>assertNotModuleName</code>
-      <code>assertNotModulesLoaded</code>
-      <code>assertNotResponseStatusCode</code>
-      <code>assertNotTemplateName</code>
-      <code>assertResponseStatusCode</code>
-      <code>assertTemplateName</code>
-      <code>dispatch</code>
-      <code>setUpCompat</code>
-      <code>tearDownCompat</code>
-    </MissingReturnType>
     <MixedArgument occurrences="19">
       <code>$child</code>
       <code>$controllerClass</code>
@@ -173,10 +198,6 @@
     <MoreSpecificReturnType occurrences="1">
       <code>ServiceManager</code>
     </MoreSpecificReturnType>
-    <PossiblyFalseArgument occurrences="2">
-      <code>strpos($controllerClass, '\\')</code>
-      <code>strpos($controllerClass, '\\')</code>
-    </PossiblyFalseArgument>
     <PossiblyFalseOperand occurrences="2">
       <code>strrpos($controllerClass, '\\')</code>
       <code>strrpos($controllerClass, '\\')</code>
@@ -230,59 +251,43 @@
     </UndefinedMethod>
   </file>
   <file src="src/PHPUnit/Controller/AbstractHttpControllerTestCase.php">
+    <DeprecatedMethod occurrences="34">
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+      <code>createFailureMessage</code>
+    </DeprecatedMethod>
     <InternalClass occurrences="34"/>
-    <InvalidReturnStatement occurrences="1">
-      <code>$this-&gt;query($path, true)</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>array</code>
-    </InvalidReturnType>
-    <MissingReturnType occurrences="44">
-      <code>assertHasResponseHeader</code>
-      <code>assertNotHasResponseHeader</code>
-      <code>assertNotQuery</code>
-      <code>assertNotQueryContentContains</code>
-      <code>assertNotQueryContentRegex</code>
-      <code>assertNotQueryCount</code>
-      <code>assertNotRedirect</code>
-      <code>assertNotRedirectRegex</code>
-      <code>assertNotRedirectTo</code>
-      <code>assertNotResponseHeaderContains</code>
-      <code>assertNotResponseHeaderRegex</code>
-      <code>assertNotXpathQuery</code>
-      <code>assertNotXpathQueryContentContains</code>
-      <code>assertNotXpathQueryContentRegex</code>
-      <code>assertNotXpathQueryCount</code>
-      <code>assertQuery</code>
-      <code>assertQueryContentContains</code>
-      <code>assertQueryContentRegex</code>
-      <code>assertQueryCount</code>
-      <code>assertQueryCountMax</code>
-      <code>assertQueryCountMin</code>
-      <code>assertRedirect</code>
-      <code>assertRedirectRegex</code>
-      <code>assertRedirectTo</code>
-      <code>assertResponseHeaderContains</code>
-      <code>assertResponseHeaderRegex</code>
-      <code>assertResponseReasonPhrase</code>
-      <code>assertXpathQuery</code>
-      <code>assertXpathQueryContentContains</code>
-      <code>assertXpathQueryContentRegex</code>
-      <code>assertXpathQueryCount</code>
-      <code>assertXpathQueryCountMax</code>
-      <code>assertXpathQueryCountMin</code>
-      <code>notQueryAssertion</code>
-      <code>notQueryContentContainsAssertion</code>
-      <code>notQueryContentRegexAssertion</code>
-      <code>notQueryCountAssertion</code>
-      <code>queryAssertion</code>
-      <code>queryContentContainsAssertion</code>
-      <code>queryContentRegexAssertion</code>
-      <code>queryCountAssertion</code>
-      <code>queryCountMaxAssertion</code>
-      <code>queryCountMinAssertion</code>
-      <code>registerXpathNamespaces</code>
-    </MissingReturnType>
     <MixedArgument occurrences="3">
       <code>$currentHeader-&gt;getFieldValue()</code>
       <code>$currentHeader-&gt;getFieldValue()</code>
@@ -355,23 +360,6 @@
     </ArgumentTypeCoercion>
   </file>
   <file src="test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php">
-    <InternalMethod occurrences="1">
-      <code>parent::setUpCompat()</code>
-    </InternalMethod>
-    <MissingReturnType occurrences="12">
-      <code>setUpCompat</code>
-      <code>testAssertConsoleOutputContains</code>
-      <code>testAssertMatchedArgumentsWithLiteralFlags</code>
-      <code>testAssertMatchedArgumentsWithMandatoryValue</code>
-      <code>testAssertMatchedArgumentsWithValue</code>
-      <code>testAssertMatchedArgumentsWithValueWithoutEqualsSign</code>
-      <code>testAssertNotResponseStatusCode</code>
-      <code>testAssertNotResponseStatusCodeWithBadCode</code>
-      <code>testAssertResponseStatusCode</code>
-      <code>testAssertResponseStatusCodeWithBadCode</code>
-      <code>testNotAssertConsoleOutputContains</code>
-      <code>testUseOfRouter</code>
-    </MissingReturnType>
     <MixedAssignment occurrences="1">
       <code>$routeMatch</code>
     </MixedAssignment>
@@ -403,34 +391,10 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/PHPUnit/Controller/AbstractControllerTestCaseTest.php">
-    <InternalMethod occurrences="4">
-      <code>parent::setUpCompat()</code>
-      <code>parent::setUpCompat()</code>
-      <code>parent::tearDownCompat()</code>
-      <code>parent::tearDownCompat()</code>
-    </InternalMethod>
     <InvalidArgument occurrences="2">
       <code>$haystack</code>
       <code>$haystack</code>
     </InvalidArgument>
-    <InvalidReturnType occurrences="1">
-      <code>array&lt;string, array&lt;string|null&gt;&gt;</code>
-    </InvalidReturnType>
-    <MissingReturnType occurrences="13">
-      <code>assertContainsCompat</code>
-      <code>assertNotContainsCompat</code>
-      <code>testAssertNotTemplateName</code>
-      <code>testAssertTemplateName</code>
-      <code>testCanHandleMultidimensionalParams</code>
-      <code>testCustomResponseObject</code>
-      <code>testDispatchWithNullParams</code>
-      <code>testExplicityPutParamsOverrideRequestContent</code>
-      <code>testPatchRequestParams</code>
-      <code>testPreserveContentOfPatchRequest</code>
-      <code>testQueryParamsDelete</code>
-      <code>testRequestWithRouteParam</code>
-      <code>testResetDoesNotCreateSessionIfNoSessionExists</code>
-    </MissingReturnType>
     <MixedArgument occurrences="3">
       <code>$message</code>
       <code>$message</code>
@@ -439,6 +403,10 @@
     <MixedArrayAccess occurrences="1">
       <code>$config['module_listener_options']['cache_dir']</code>
     </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="2">
+      <code>$applicationConfig['module_listener_options']['module_paths']</code>
+      <code>$applicationConfig['modules'][]</code>
+    </MixedArrayAssignment>
     <MixedAssignment occurrences="2">
       <code>$config</code>
       <code>$file</code>
@@ -478,76 +446,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>'RuntimeException'</code>
     </ArgumentTypeCoercion>
-    <InternalMethod occurrences="1">
-      <code>parent::setUpCompat()</code>
-    </InternalMethod>
-    <MissingReturnType occurrences="65">
-      <code>setUpCompat</code>
-      <code>testAssertApplicationEvents</code>
-      <code>testAssertApplicationMvcEvent</code>
-      <code>testAssertExceptionAndMessageInAction</code>
-      <code>testAssertExceptionInAction</code>
-      <code>testAssertHasResponseHeader</code>
-      <code>testAssertNotHasResponseHeader</code>
-      <code>testAssertNotQuery</code>
-      <code>testAssertNotQueryContentContains</code>
-      <code>testAssertNotQueryContentRegex</code>
-      <code>testAssertNotQueryCount</code>
-      <code>testAssertNotRedirect</code>
-      <code>testAssertNotRedirectRegex</code>
-      <code>testAssertNotRedirectTo</code>
-      <code>testAssertNotResponseHeaderContains</code>
-      <code>testAssertNotResponseHeaderContainsMultipleHeaderInterface</code>
-      <code>testAssertNotResponseHeaderRegex</code>
-      <code>testAssertNotResponseHeaderRegexMultipleHeaderInterface</code>
-      <code>testAssertNotResponseStatusCode</code>
-      <code>testAssertNotXpathQuery</code>
-      <code>testAssertNotXpathQueryContentContains</code>
-      <code>testAssertNotXpathQueryContentRegex</code>
-      <code>testAssertNotXpathQueryCount</code>
-      <code>testAssertQuery</code>
-      <code>testAssertQueryContentContains</code>
-      <code>testAssertQueryContentContainsWithSecondElement</code>
-      <code>testAssertQueryContentRegex</code>
-      <code>testAssertQueryContentRegexMultipleMatches</code>
-      <code>testAssertQueryContentRegexMultipleMatchesNoFalsePositive</code>
-      <code>testAssertQueryCount</code>
-      <code>testAssertQueryCountMax</code>
-      <code>testAssertQueryCountMin</code>
-      <code>testAssertQueryWithDynamicPostParams</code>
-      <code>testAssertQueryWithDynamicPostParamsInDispatchMethod</code>
-      <code>testAssertQueryWithDynamicPutParamsInDispatchMethod</code>
-      <code>testAssertQueryWithDynamicQueryParams</code>
-      <code>testAssertQueryWithDynamicQueryParamsInDispatchMethod</code>
-      <code>testAssertQueryWithDynamicQueryParamsInUrl</code>
-      <code>testAssertQueryWithDynamicQueryParamsInUrlAnsPostInParams</code>
-      <code>testAssertRedirect</code>
-      <code>testAssertRedirectRegex</code>
-      <code>testAssertRedirectTo</code>
-      <code>testAssertResponseHeaderContains</code>
-      <code>testAssertResponseHeaderContainsMultipleHeaderInterface</code>
-      <code>testAssertResponseHeaderRegex</code>
-      <code>testAssertResponseHeaderRegexMultipleHeaderInterface</code>
-      <code>testAssertResponseReasonPhrase</code>
-      <code>testAssertResponseStatusCode</code>
-      <code>testAssertUriWithHostname</code>
-      <code>testAssertWithEventShared</code>
-      <code>testAssertWithMultiDispatch</code>
-      <code>testAssertWithMultiDispatchWithPersistence</code>
-      <code>testAssertWithMultiDispatchWithoutPersistence</code>
-      <code>testAssertXmlHttpRequestDispatch</code>
-      <code>testAssertXpathQuery</code>
-      <code>testAssertXpathQueryContentContains</code>
-      <code>testAssertXpathQueryContentRegex</code>
-      <code>testAssertXpathQueryCount</code>
-      <code>testAssertXpathQueryCountMax</code>
-      <code>testAssertXpathQueryCountMin</code>
-      <code>testAssertXpathQueryCountWithBadXpathUsage</code>
-      <code>testAssertXpathQueryWithBadXpathUsage</code>
-      <code>testGetErrorWithTraceErrorEnabled</code>
-      <code>testTraceErrorEnableByDefault</code>
-      <code>testUseOfRouter</code>
-    </MissingReturnType>
     <MixedArgument occurrences="6">
       <code>$layout-&gt;getChildren()</code>
       <code>$messages</code>
@@ -628,14 +526,8 @@
       <code>setMethod</code>
       <code>setMethod</code>
     </UndefinedInterfaceMethod>
-    <UnusedVariable occurrences="1">
-      <code>$result</code>
-    </UnusedVariable>
   </file>
   <file src="test/PHPUnit/Controller/MemoryLeakTest.php">
-    <MissingReturnType occurrences="1">
-      <code>setUpBeforeClassCompat</code>
-    </MissingReturnType>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
@@ -646,19 +538,14 @@
       <code>assertNull</code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="test/PHPUnit/ModuleDependenciesTest.php">
-    <MissingReturnType occurrences="2">
-      <code>testBadDependenciesModules</code>
-      <code>testDependenciesModules</code>
-    </MissingReturnType>
-  </file>
   <file src="test/PHPUnit/Util/ModuleLoaderTest.php">
-    <ArgumentTypeCoercion occurrences="6">
+    <ArgumentTypeCoercion occurrences="7">
       <code>'Baz\Module'</code>
       <code>'Baz\Module'</code>
       <code>'Baz\Module'</code>
       <code>'Baz\Module'</code>
       <code>'Foo\Module'</code>
+      <code>'ModuleWithNamespace\TestModule\Module'</code>
       <code>'stdClass'</code>
     </ArgumentTypeCoercion>
     <MixedAssignment occurrences="7">
@@ -670,9 +557,6 @@
       <code>$foo</code>
       <code>$fooObject</code>
     </MixedAssignment>
-    <UnusedVariable occurrences="1">
-      <code>$loader</code>
-    </UnusedVariable>
   </file>
   <file src="test/_files/Baz/src/Baz/Controller/IndexController.php">
     <MixedAssignment occurrences="2">

--- a/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
+++ b/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Test\PHPUnit\Constraint;
+
+final class IsCurrentModuleNameConstraint extends LaminasConstraint
+{
+    public function toString(): string
+    {
+        return 'is the actual module name';
+    }
+
+    public function failureDescription($other): string
+    {
+        return "\"$other\" {$this->toString()}, actual module name is \"{$this->getCurrentModuleName()}\"";
+    }
+
+    public function matches($other): bool
+    {
+        return  (strtolower($other) === $this->getCurrentModuleName());
+    }
+
+    public function getCurrentModuleName(): string
+    {
+        $controllerClass = $this->getControllerFullClassName();
+        $match = '';
+
+        $applicationConfig = $this->getTestCase()->getApplicationConfig();
+
+        // Find Module from Controller
+        foreach ($applicationConfig['modules'] as $appModules) {
+            if (strpos($controllerClass, $appModules) !== false) {
+                if (strpos($appModules, '\\') !== false) {
+                    $match = ltrim(substr($appModules, strrpos($appModules, '\\')), '\\');
+                } else {
+                    $match = ltrim($appModules);
+                }
+            }
+        }
+
+        return strtolower($match);
+    }
+}

--- a/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
+++ b/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\Test\PHPUnit\Constraint;
 
+use function ltrim;
+use function strpos;
+use function strrpos;
+use function strtolower;
+use function substr;
+
 final class IsCurrentModuleNameConstraint extends LaminasConstraint
 {
     public function toString(): string
@@ -11,20 +17,24 @@ final class IsCurrentModuleNameConstraint extends LaminasConstraint
         return 'is the actual module name';
     }
 
+    /** @param mixed $other */
     public function failureDescription($other): string
     {
+        $other = (string) $other;
         return "\"$other\" {$this->toString()}, actual module name is \"{$this->getCurrentModuleName()}\"";
     }
 
+    /** @param mixed $other */
     public function matches($other): bool
     {
-        return  (strtolower($other) === $this->getCurrentModuleName());
+        $other = (string) $other;
+        return strtolower($other) === $this->getCurrentModuleName();
     }
 
     public function getCurrentModuleName(): string
     {
         $controllerClass = $this->getControllerFullClassName();
-        $match = '';
+        $match           = '';
 
         $applicationConfig = $this->getTestCase()->getApplicationConfig();
 

--- a/src/PHPUnit/Constraint/LaminasConstraint.php
+++ b/src/PHPUnit/Constraint/LaminasConstraint.php
@@ -37,7 +37,7 @@ abstract class LaminasConstraint extends Constraint
         }
     }
 
-    final protected function getControllerFullClassName(): string
+    final public function getControllerFullClassName(): string
     {
         $routeMatch           = $this->activeTestCase->getApplication()->getMvcEvent()->getRouteMatch();
         $controllerIdentifier = $routeMatch->getParam('controller');

--- a/src/PHPUnit/Constraint/LaminasConstraint.php
+++ b/src/PHPUnit/Constraint/LaminasConstraint.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Test\PHPUnit\Constraint;
+
+use Laminas\Test\PHPUnit\Controller\AbstractControllerTestCase;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+abstract class LaminasConstraint extends Constraint
+{
+    protected $activeTestCase;
+
+    public function __construct(AbstractControllerTestCase $activeTestCase)
+    {
+        $this->activeTestCase = $activeTestCase;
+    }
+
+    final public function getTestCase(): AbstractControllerTestCase
+    {
+        return $this->activeTestCase;
+    }
+
+    protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): void
+    {
+        $failureDescription = sprintf(
+            'Failed asserting that %s.',
+            $this->failureDescription($other)
+        );
+
+        $additionalFailureDescription = $this->additionalFailureDescription($other);
+
+        if ($additionalFailureDescription) {
+            $failureDescription .= "\n" . $additionalFailureDescription;
+        }
+
+        if (! empty($description)) {
+            $failureDescription = $description . "\n" . $failureDescription;
+        }
+
+        throw new ExpectationFailedException(
+            $this->createFailureMessage($failureDescription),
+            $comparisonFailure
+        );
+    }
+
+    final protected function getControllerFullClassName(): string
+    {
+        $routeMatch           = $this->activeTestCase->getApplication()->getMvcEvent()->getRouteMatch();
+        $controllerIdentifier = $routeMatch->getParam('controller');
+
+        $controllerManager    = $this->activeTestCase->getApplicationServiceLocator()->get('ControllerManager');
+
+        return get_class($controllerManager->get($controllerIdentifier));
+    }
+
+
+
+    /**
+     * Create a failure message.
+     *
+     * If $traceError is true, appends exception details, if any.
+     */
+    final private function createFailureMessage(string $message): string
+    {
+        if (true !== $this->activeTestCase->getTraceError()) {
+            return $message;
+        }
+
+        $exception = $this->activeTestCase->getApplication()->getMvcEvent()->getParam('exception');
+        if (! $exception instanceof \Throwable && ! $exception instanceof \Exception) {
+            return $message;
+        }
+
+        $messages = [];
+        do {
+            $messages[] = sprintf(
+                "Exception '%s' with message '%s' in %s:%d",
+                get_class($exception),
+                $exception->getMessage(),
+                $exception->getFile(),
+                $exception->getLine()
+            );
+        } while ($exception = $exception->getPrevious());
+
+        return sprintf("%s\n\nExceptions raised:\n%s\n", $message, implode("\n\n", $messages));
+    }
+}

--- a/src/PHPUnit/Constraint/LaminasConstraint.php
+++ b/src/PHPUnit/Constraint/LaminasConstraint.php
@@ -4,15 +4,21 @@ declare(strict_types=1);
 
 namespace Laminas\Test\PHPUnit\Constraint;
 
+use Exception;
 use Laminas\Test\PHPUnit\Controller\AbstractControllerTestCase;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\Comparator\ComparisonFailure;
-use Exception;
 use Throwable;
 
+use function get_class;
+use function implode;
+use function sprintf;
+
+// @codingStandardsIgnoreLine
 abstract class LaminasConstraint extends Constraint
 {
+    /** @var AbstractControllerTestCase */
     protected $activeTestCase;
 
     public function __construct(AbstractControllerTestCase $activeTestCase)
@@ -25,7 +31,12 @@ abstract class LaminasConstraint extends Constraint
         return $this->activeTestCase;
     }
 
-    final public function fail($other, $description, ComparisonFailure $comparisonFailure = null): void
+    /**
+     * @param mixed $other
+     * @param string $description
+     * @psalm-return never
+     */
+    final public function fail($other, $description, ?ComparisonFailure $comparisonFailure = null): void
     {
         try {
             parent::fail($other, $description, $comparisonFailure);
@@ -42,7 +53,7 @@ abstract class LaminasConstraint extends Constraint
         $routeMatch           = $this->activeTestCase->getApplication()->getMvcEvent()->getRouteMatch();
         $controllerIdentifier = $routeMatch->getParam('controller');
 
-        $controllerManager    = $this->activeTestCase->getApplicationServiceLocator()->get('ControllerManager');
+        $controllerManager = $this->activeTestCase->getApplicationServiceLocator()->get('ControllerManager');
 
         return get_class($controllerManager->get($controllerIdentifier));
     }

--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -19,6 +19,8 @@ use Laminas\Stdlib\Exception\LogicException;
 use Laminas\Stdlib\Parameters;
 use Laminas\Stdlib\RequestInterface;
 use Laminas\Stdlib\ResponseInterface;
+use Laminas\Test\PHPUnit\Constraint\IsCurrentModuleNameConstraint;
+use Laminas\Test\PHPUnit\TestCaseTrait;
 use Laminas\Uri\Http as HttpUri;
 use Laminas\View\Model\ModelInterface;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -101,6 +103,8 @@ abstract class AbstractControllerTestCase extends TestCase
      * Create a failure message.
      *
      * If $traceError is true, appends exception details, if any.
+     *
+     * @deprecated (use LaminasContraint instead)
      *
      * @param string $message
      * @return string
@@ -570,50 +574,21 @@ abstract class AbstractControllerTestCase extends TestCase
 
     /**
      * Assert that the application route match used the given module
-     *
-     * @param string $module
      */
-    public function assertModuleName($module)
+    final public function assertModuleName(string $module): void
     {
-        $controllerClass = $this->getControllerFullClassName();
-        $match = '';
-
-        // Find Module from Controller
-        foreach ($this->applicationConfig['modules'] as $appModules) {
-            if (strpos($controllerClass, $appModules) !== false) {
-                $match = ltrim(substr($appModules, strrpos($appModules, '\\')), '\\');
-            }
-        }
-
-        $match  = strtolower($match);
-        $module = strtolower($module);
-
-        if ($module !== $match) {
-            throw new ExpectationFailedException($this->createFailureMessage(
-                sprintf('Failed asserting module name "%s", actual module name is "%s"', $module, $match)
-            ));
-        }
-
-        $this->assertEquals($module, $match);
+        self::assertThat($module, new IsCurrentModuleNameConstraint($this));
     }
 
     /**
      * Assert that the application route match used NOT the given module
-     *
-     * @param string $module
      */
-    public function assertNotModuleName($module)
+    final public function assertNotModuleName(string $module): void
     {
-        $controllerClass = $this->getControllerFullClassName();
-        $match           = substr($controllerClass, 0, strpos($controllerClass, '\\'));
-        $match           = strtolower($match);
-        $module          = strtolower($module);
-        if ($module === $match) {
-            throw new ExpectationFailedException($this->createFailureMessage(
-                sprintf('Failed asserting module was NOT "%s"', $module)
-            ));
-        }
-        $this->assertNotEquals($module, $match);
+        self::assertThat(
+            $module,
+            self::logicalNot(new IsCurrentModuleNameConstraint($this))
+        );
     }
 
     /**

--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -574,16 +574,20 @@ abstract class AbstractControllerTestCase extends TestCase
 
     /**
      * Assert that the application route match used the given module
+     *
+     * @param string $module
      */
-    final public function assertModuleName(string $module): void
+    public function assertModuleName($module)
     {
         self::assertThat($module, new IsCurrentModuleNameConstraint($this));
     }
 
     /**
      * Assert that the application route match used NOT the given module
+     *
+     * @param string $module
      */
-    final public function assertNotModuleName(string $module): void
+    public function assertNotModuleName($module)
     {
         self::assertThat(
             $module,

--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -20,7 +20,6 @@ use Laminas\Stdlib\Parameters;
 use Laminas\Stdlib\RequestInterface;
 use Laminas\Stdlib\ResponseInterface;
 use Laminas\Test\PHPUnit\Constraint\IsCurrentModuleNameConstraint;
-use Laminas\Test\PHPUnit\TestCaseTrait;
 use Laminas\Uri\Http as HttpUri;
 use Laminas\View\Model\ModelInterface;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -42,7 +41,6 @@ use function parse_str;
 use function preg_match_all;
 use function sprintf;
 use function str_replace;
-use function strpos;
 use function strrpos;
 use function strtolower;
 use function substr;
@@ -329,10 +327,11 @@ abstract class AbstractControllerTestCase extends TestCase
      *
      * The URL provided set the request URI in the request object.
      *
-     * @param  string      $url
-     * @param  string|null $method
-     * @param  array|null  $params
-     * @param  bool        $isXmlHttpRequest
+     * @param string      $url
+     * @param string|null $method
+     * @param array|null  $params
+     * @param bool        $isXmlHttpRequest
+     * @return void
      * @throws Exception
      */
     public function dispatch($url, $method = null, $params = [], $isXmlHttpRequest = false)
@@ -404,7 +403,7 @@ abstract class AbstractControllerTestCase extends TestCase
             return $events->trigger($eventName, $event);
         }
 
-        $shortCircuit = function ($r) use ($event) {
+        $shortCircuit = function ($r) use ($event): bool {
             if ($r instanceof ResponseInterface) {
                 return true;
             }
@@ -424,6 +423,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert modules were loaded with the module manager
      *
      * @param array $modules
+     * @return void
      */
     public function assertModulesLoaded(array $modules)
     {
@@ -442,6 +442,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert modules were not loaded with the module manager
      *
      * @param array $modules
+     * @return void
      */
     public function assertNotModulesLoaded(array $modules)
     {
@@ -480,6 +481,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert response status code
      *
      * @param int $code
+     * @return void
      */
     public function assertResponseStatusCode($code)
     {
@@ -503,6 +505,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert not response status code
      *
      * @param int $code
+     * @return void
      */
     public function assertNotResponseStatusCode($code)
     {
@@ -527,6 +530,7 @@ abstract class AbstractControllerTestCase extends TestCase
      *
      * @param string $type application exception type
      * @param string|null $message application exception message
+     * @psalm-return never
      */
     public function assertApplicationException($type, $message = null)
     {
@@ -576,6 +580,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that the application route match used the given module
      *
      * @param string $module
+     * @return void
      */
     public function assertModuleName($module)
     {
@@ -586,6 +591,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that the application route match used NOT the given module
      *
      * @param string $module
+     * @return void
      */
     public function assertNotModuleName($module)
     {
@@ -599,6 +605,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that the application route match used the given controller class
      *
      * @param string $controller
+     * @return void
      */
     public function assertControllerClass($controller)
     {
@@ -618,6 +625,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that the application route match used NOT the given controller class
      *
      * @param string $controller
+     * @return void
      */
     public function assertNotControllerClass($controller)
     {
@@ -637,6 +645,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that the application route match used the given controller name
      *
      * @param string $controller
+     * @return void
      */
     public function assertControllerName($controller)
     {
@@ -659,6 +668,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that the application route match used NOT the given controller name
      *
      * @param string $controller
+     * @return void
      */
     public function assertNotControllerName($controller)
     {
@@ -681,6 +691,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that the application route match used the given action
      *
      * @param string $action
+     * @return void
      */
     public function assertActionName($action)
     {
@@ -703,6 +714,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that the application route match used NOT the given action
      *
      * @param string $action
+     * @return void
      */
     public function assertNotActionName($action)
     {
@@ -725,6 +737,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that the application route match used the given route name
      *
      * @param string $route
+     * @return void
      */
     public function assertMatchedRouteName($route)
     {
@@ -751,6 +764,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that the application route match used NOT the given route name
      *
      * @param string $route
+     * @return void
      */
     public function assertNotMatchedRouteName($route)
     {
@@ -771,6 +785,8 @@ abstract class AbstractControllerTestCase extends TestCase
 
     /**
      * Assert that the application did not match any route
+     *
+     * @return void
      */
     public function assertNoMatchedRoute()
     {
@@ -791,6 +807,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that a template was used somewhere in the view model tree
      *
      * @param string $templateName
+     * @return void
      */
     public function assertTemplateName($templateName)
     {
@@ -803,6 +820,7 @@ abstract class AbstractControllerTestCase extends TestCase
      * Assert that a template was not used somewhere in the view model tree
      *
      * @param string $templateName
+     * @return void
      */
     public function assertNotTemplateName($templateName)
     {

--- a/src/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -576,14 +576,24 @@ abstract class AbstractControllerTestCase extends TestCase
     public function assertModuleName($module)
     {
         $controllerClass = $this->getControllerFullClassName();
-        $match           = substr($controllerClass, 0, strpos($controllerClass, '\\'));
-        $match           = strtolower($match);
-        $module          = strtolower($module);
+        $match = '';
+
+        // Find Module from Controller
+        foreach ($this->applicationConfig['modules'] as $appModules) {
+            if (strpos($controllerClass, $appModules) !== false) {
+                $match = ltrim(substr($appModules, strrpos($appModules, '\\')), '\\');
+            }
+        }
+
+        $match  = strtolower($match);
+        $module = strtolower($module);
+
         if ($module !== $match) {
             throw new ExpectationFailedException($this->createFailureMessage(
                 sprintf('Failed asserting module name "%s", actual module name is "%s"', $module, $match)
             ));
         }
+
         $this->assertEquals($module, $match);
     }
 

--- a/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php
@@ -49,6 +49,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
      * Assert response has the given reason phrase
      *
      * @param string $phrase
+     * @return void
      */
     public function assertResponseReasonPhrase($phrase)
     {
@@ -58,7 +59,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert response header exists
      *
-     * @param  string $header
+     * @param string $header
+     * @return void
      */
     public function assertHasResponseHeader($header)
     {
@@ -75,7 +77,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert response header does not exist
      *
-     * @param  string $header
+     * @param string $header
+     * @return void
      */
     public function assertNotHasResponseHeader($header)
     {
@@ -92,8 +95,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert response header exists and contains the given string
      *
-     * @param  string $header
-     * @param  string $match
+     * @param string $header
+     * @param string $match
+     * @return void
      */
     public function assertResponseHeaderContains($header, $match)
     {
@@ -133,8 +137,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert response header exists and contains the given string
      *
-     * @param  string $header
-     * @param  string $match
+     * @param string $header
+     * @param string $match
+     * @return void
      */
     public function assertNotResponseHeaderContains($header, $match)
     {
@@ -166,8 +171,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert response header exists and matches the given pattern
      *
-     * @param  string $header
-     * @param  string $pattern
+     * @param string $header
+     * @param string $pattern
+     * @return void
      */
     public function assertResponseHeaderRegex($header, $pattern)
     {
@@ -208,8 +214,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert response header does not exist and/or does not match the given regex
      *
-     * @param  string $header
-     * @param  string $pattern
+     * @param string $header
+     * @param string $pattern
+     * @return void
      */
     public function assertNotResponseHeaderRegex($header, $pattern)
     {
@@ -244,6 +251,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
 
     /**
      * Assert that response is a redirect
+     *
+     * @return void
      */
     public function assertRedirect()
     {
@@ -258,6 +267,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
 
     /**
      * Assert that response is NOT a redirect
+     *
+     * @return void
      */
     public function assertNotRedirect()
     {
@@ -274,7 +285,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert that response redirects to given URL
      *
-     * @param  string $url
+     * @param string $url
+     * @return void
      */
     public function assertRedirectTo($url)
     {
@@ -297,7 +309,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert that response does not redirect to given URL
      *
-     * @param  string $url
+     * @param string $url
+     * @return void
      */
     public function assertNotRedirectTo($url)
     {
@@ -319,7 +332,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert that redirect location matches pattern
      *
-     * @param  string $pattern
+     * @param string $pattern
+     * @return void
      */
     public function assertRedirectRegex($pattern)
     {
@@ -342,7 +356,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert that redirect location does not match pattern
      *
-     * @param  string $pattern
+     * @param string $pattern
+     * @return void
      */
     public function assertNotRedirectRegex($pattern)
     {
@@ -364,7 +379,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Register XPath namespaces
      *
-     * @param   array $xpathNamespaces
+     * @param array $xpathNamespaces
+     * @return void
      */
     public function registerXpathNamespaces(array $xpathNamespaces)
     {
@@ -397,10 +413,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Execute a xpath query
      *
-     * @param  string $path
-     * @return array
+     * @param string $path
      */
-    private function xpathQuery($path)
+    private function xpathQuery($path): Document\NodeList
     {
         return $this->query($path, true);
     }
@@ -446,7 +461,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
      * @param string $path
      * @param bool $useXpath
      */
-    private function queryAssertion($path, $useXpath = false)
+    private function queryAssertion($path, $useXpath = false): void
     {
         $match = $this->queryCountOrxpathQueryCount($path, $useXpath);
         if (! $match > 0) {
@@ -461,7 +476,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM selection
      *
-     * @param  string $path CSS selector path
+     * @param string $path CSS selector path
+     * @return void
      */
     public function assertQuery($path)
     {
@@ -471,7 +487,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against XPath selection
      *
-     * @param  string $path XPath path
+     * @param string $path XPath path
+     * @return void
      */
     public function assertXpathQuery($path)
     {
@@ -484,7 +501,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
      * @param string $path CSS selector path
      * @param bool $useXpath
      */
-    private function notQueryAssertion($path, $useXpath = false)
+    private function notQueryAssertion($path, $useXpath = false): void
     {
         $match = $this->queryCountOrxpathQueryCount($path, $useXpath);
         if ($match !== 0) {
@@ -499,7 +516,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM selection
      *
-     * @param  string $path CSS selector path
+     * @param string $path CSS selector path
+     * @return void
      */
     public function assertNotQuery($path)
     {
@@ -509,7 +527,8 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against XPath selection
      *
-     * @param  string $path XPath path
+     * @param string $path XPath path
+     * @return void
      */
     public function assertNotXpathQuery($path)
     {
@@ -523,7 +542,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
      * @param int $count Number of nodes that should match
      * @param bool $useXpath
      */
-    private function queryCountAssertion($path, $count, $useXpath = false)
+    private function queryCountAssertion($path, $count, $useXpath = false): void
     {
         $match = $this->queryCountOrxpathQueryCount($path, $useXpath);
         if ($match !== $count) {
@@ -540,8 +559,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM selection; should contain exact number of nodes
      *
-     * @param  string $path CSS selector path
-     * @param  int $count Number of nodes that should match
+     * @param string $path CSS selector path
+     * @param int $count Number of nodes that should match
+     * @return void
      */
     public function assertQueryCount($path, $count)
     {
@@ -551,8 +571,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against XPath selection; should contain exact number of nodes
      *
-     * @param  string $path XPath path
-     * @param  int $count Number of nodes that should match
+     * @param string $path XPath path
+     * @param int $count Number of nodes that should match
+     * @return void
      */
     public function assertXpathQueryCount($path, $count)
     {
@@ -562,11 +583,11 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM/XPath selection; should NOT contain exact number of nodes
      *
-     * @param  string $path CSS selector path
-     * @param  int $count Number of nodes that should NOT match
+     * @param string $path CSS selector path
+     * @param int $count Number of nodes that should NOT match
      * @param bool $useXpath
      */
-    private function notQueryCountAssertion($path, $count, $useXpath = false)
+    private function notQueryCountAssertion($path, $count, $useXpath = false): void
     {
         $match = $this->queryCountOrxpathQueryCount($path, $useXpath);
         if ($match === $count) {
@@ -582,8 +603,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM selection; should NOT contain exact number of nodes
      *
-     * @param  string $path CSS selector path
-     * @param  int $count Number of nodes that should NOT match
+     * @param string $path CSS selector path
+     * @param int $count Number of nodes that should NOT match
+     * @return void
      */
     public function assertNotQueryCount($path, $count)
     {
@@ -593,8 +615,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against XPath selection; should NOT contain exact number of nodes
      *
-     * @param  string $path XPath path
-     * @param  int $count Number of nodes that should NOT match
+     * @param string $path XPath path
+     * @param int $count Number of nodes that should NOT match
+     * @return void
      */
     public function assertNotXpathQueryCount($path, $count)
     {
@@ -608,7 +631,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
      * @param int $count Minimum number of nodes that should match
      * @param bool $useXpath
      */
-    private function queryCountMinAssertion($path, $count, $useXpath = false)
+    private function queryCountMinAssertion($path, $count, $useXpath = false): void
     {
         $match = $this->queryCountOrxpathQueryCount($path, $useXpath);
         if ($match < $count) {
@@ -625,8 +648,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM selection; should contain at least this number of nodes
      *
-     * @param  string $path CSS selector path
-     * @param  int $count Minimum number of nodes that should match
+     * @param string $path CSS selector path
+     * @param int $count Minimum number of nodes that should match
+     * @return void
      */
     public function assertQueryCountMin($path, $count)
     {
@@ -636,8 +660,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against XPath selection; should contain at least this number of nodes
      *
-     * @param  string $path XPath path
-     * @param  int $count Minimum number of nodes that should match
+     * @param string $path XPath path
+     * @param int $count Minimum number of nodes that should match
+     * @return void
      */
     public function assertXpathQueryCountMin($path, $count)
     {
@@ -647,11 +672,11 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM/XPath selection; should contain no more than this number of nodes
      *
-     * @param  string $path CSS selector path
-     * @param  int $count Maximum number of nodes that should match
+     * @param string $path CSS selector path
+     * @param int $count Maximum number of nodes that should match
      * @param bool $useXpath
      */
-    private function queryCountMaxAssertion($path, $count, $useXpath = false)
+    private function queryCountMaxAssertion($path, $count, $useXpath = false): void
     {
         $match = $this->queryCountOrxpathQueryCount($path, $useXpath);
         if ($match > $count) {
@@ -668,8 +693,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM selection; should contain no more than this number of nodes
      *
-     * @param  string $path CSS selector path
-     * @param  int $count Maximum number of nodes that should match
+     * @param string $path CSS selector path
+     * @param int $count Maximum number of nodes that should match
+     * @return void
      */
     public function assertQueryCountMax($path, $count)
     {
@@ -679,8 +705,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against XPath selection; should contain no more than this number of nodes
      *
-     * @param  string $path XPath path
-     * @param  int $count Maximum number of nodes that should match
+     * @param string $path XPath path
+     * @param int $count Maximum number of nodes that should match
+     * @return void
      */
     public function assertXpathQueryCountMax($path, $count)
     {
@@ -690,11 +717,11 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM/XPath selection; node should contain content
      *
-     * @param  string $path CSS selector path
-     * @param  string $match content that should be contained in matched nodes
+     * @param string $path CSS selector path
+     * @param string $match content that should be contained in matched nodes
      * @param bool $useXpath
      */
-    private function queryContentContainsAssertion($path, $match, $useXpath = false)
+    private function queryContentContainsAssertion($path, $match, $useXpath = false): void
     {
         $result = $this->query($path, $useXpath);
 
@@ -727,8 +754,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM selection; node should contain content
      *
-     * @param  string $path CSS selector path
-     * @param  string $match content that should be contained in matched nodes
+     * @param string $path CSS selector path
+     * @param string $match content that should be contained in matched nodes
+     * @return void
      */
     public function assertQueryContentContains($path, $match)
     {
@@ -738,8 +766,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against XPath selection; node should contain content
      *
-     * @param  string $path XPath path
-     * @param  string $match content that should be contained in matched nodes
+     * @param string $path XPath path
+     * @param string $match content that should be contained in matched nodes
+     * @return void
      */
     public function assertXpathQueryContentContains($path, $match)
     {
@@ -749,11 +778,11 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM/XPath selection; node should NOT contain content
      *
-     * @param  string $path CSS selector path
-     * @param  string $match content that should NOT be contained in matched nodes
+     * @param string $path CSS selector path
+     * @param string $match content that should NOT be contained in matched nodes
      * @param bool $useXpath
      */
-    private function notQueryContentContainsAssertion($path, $match, $useXpath = false)
+    private function notQueryContentContainsAssertion($path, $match, $useXpath = false): void
     {
         $result = $this->query($path, $useXpath);
         if ($result->count() === 0) {
@@ -778,8 +807,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM selection; node should NOT contain content
      *
-     * @param  string $path CSS selector path
-     * @param  string $match content that should NOT be contained in matched nodes
+     * @param string $path CSS selector path
+     * @param string $match content that should NOT be contained in matched nodes
+     * @return void
      */
     public function assertNotQueryContentContains($path, $match)
     {
@@ -789,8 +819,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against XPath selection; node should NOT contain content
      *
-     * @param  string $path XPath path
-     * @param  string $match content that should NOT be contained in matched nodes
+     * @param string $path XPath path
+     * @param string $match content that should NOT be contained in matched nodes
+     * @return void
      */
     public function assertNotXpathQueryContentContains($path, $match)
     {
@@ -800,11 +831,11 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM/XPath selection; node should match content
      *
-     * @param  string $path CSS selector path
-     * @param  string $pattern Pattern that should be contained in matched nodes
+     * @param string $path CSS selector path
+     * @param string $pattern Pattern that should be contained in matched nodes
      * @param bool $useXpath
      */
-    private function queryContentRegexAssertion($path, $pattern, $useXpath = false)
+    private function queryContentRegexAssertion($path, $pattern, $useXpath = false): void
     {
         $result = $this->query($path, $useXpath);
         if ($result->count() === 0) {
@@ -840,8 +871,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM selection; node should match content
      *
-     * @param  string $path CSS selector path
-     * @param  string $pattern Pattern that should be contained in matched nodes
+     * @param string $path CSS selector path
+     * @param string $pattern Pattern that should be contained in matched nodes
+     * @return void
      */
     public function assertQueryContentRegex($path, $pattern)
     {
@@ -851,8 +883,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against XPath selection; node should match content
      *
-     * @param  string $path XPath path
-     * @param  string $pattern Pattern that should be contained in matched nodes
+     * @param string $path XPath path
+     * @param string $pattern Pattern that should be contained in matched nodes
+     * @return void
      */
     public function assertXpathQueryContentRegex($path, $pattern)
     {
@@ -866,7 +899,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
      * @param string $pattern pattern that should NOT be contained in matched nodes
      * @param bool $useXpath
      */
-    private function notQueryContentRegexAssertion($path, $pattern, $useXpath = false)
+    private function notQueryContentRegexAssertion($path, $pattern, $useXpath = false): void
     {
         $result = $this->query($path, $useXpath);
         if ($result->count() === 0) {
@@ -888,8 +921,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against DOM selection; node should NOT match content
      *
-     * @param  string $path CSS selector path
-     * @param  string $pattern pattern that should NOT be contained in matched nodes
+     * @param string $path CSS selector path
+     * @param string $pattern pattern that should NOT be contained in matched nodes
+     * @return void
      */
     public function assertNotQueryContentRegex($path, $pattern)
     {
@@ -899,8 +933,9 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     /**
      * Assert against XPath selection; node should NOT match content
      *
-     * @param  string $path XPath path
-     * @param  string $pattern pattern that should NOT be contained in matched nodes
+     * @param string $path XPath path
+     * @param string $pattern pattern that should NOT be contained in matched nodes
+     * @return void
      */
     public function assertNotXpathQueryContentRegex($path, $pattern)
     {

--- a/test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php
@@ -26,12 +26,12 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         parent::setUp();
     }
 
-    public function testUseOfRouter()
+    public function testUseOfRouter(): void
     {
         $this->assertEquals(true, $this->useConsoleRequest);
     }
 
-    public function testAssertResponseStatusCode()
+    public function testAssertResponseStatusCode(): void
     {
         $this->dispatch('--console');
         $this->assertResponseStatusCode(0);
@@ -43,7 +43,7 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertResponseStatusCode(1);
     }
 
-    public function testAssertNotResponseStatusCode()
+    public function testAssertNotResponseStatusCode(): void
     {
         $this->dispatch('--console');
         $this->assertNotResponseStatusCode(1);
@@ -52,7 +52,7 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertNotResponseStatusCode(0);
     }
 
-    public function testAssertResponseStatusCodeWithBadCode()
+    public function testAssertResponseStatusCodeWithBadCode(): void
     {
         $this->dispatch('--console');
         $this->expectedException(
@@ -62,7 +62,7 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertResponseStatusCode(2);
     }
 
-    public function testAssertNotResponseStatusCodeWithBadCode()
+    public function testAssertNotResponseStatusCodeWithBadCode(): void
     {
         $this->dispatch('--console');
         $this->expectedException(
@@ -72,7 +72,7 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertNotResponseStatusCode(2);
     }
 
-    public function testAssertConsoleOutputContains()
+    public function testAssertConsoleOutputContains(): void
     {
         $this->dispatch('--console');
         $this->assertConsoleOutputContains('foo');
@@ -85,7 +85,7 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertConsoleOutputContains('baz');
     }
 
-    public function testNotAssertConsoleOutputContains()
+    public function testNotAssertConsoleOutputContains(): void
     {
         $this->dispatch('--console');
         $this->assertNotConsoleOutputContains('baz');
@@ -94,7 +94,7 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertNotConsoleOutputContains('foo');
     }
 
-    public function testAssertMatchedArgumentsWithValue()
+    public function testAssertMatchedArgumentsWithValue(): void
     {
         $this->dispatch('filter --date="2013-03-07 00:00:00" --id=10 --text="custom text"');
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
@@ -107,7 +107,7 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
     /**
      * @group 6837
      */
-    public function testAssertMatchedArgumentsWithMandatoryValue()
+    public function testAssertMatchedArgumentsWithMandatoryValue(): void
     {
         $this->dispatch("foo --bar='FOO' --baz='ARE'");
         /** @var \Laminas\Mvc\Router\Console\RouteMatch $routeMatch */
@@ -124,7 +124,7 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertEquals('arguments-mandatory', $routeMatch->getMatchedRouteName());
     }
 
-    public function testAssertMatchedArgumentsWithValueWithoutEqualsSign()
+    public function testAssertMatchedArgumentsWithValueWithoutEqualsSign(): void
     {
         $this->dispatch('filter --date "2013-03-07 00:00:00" --id=10 --text="custom text"');
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
@@ -134,7 +134,7 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertEquals("custom text", $routeMatch->getParam('text'));
     }
 
-    public function testAssertMatchedArgumentsWithLiteralFlags()
+    public function testAssertMatchedArgumentsWithLiteralFlags(): void
     {
         $this->dispatch('literal --foo --bar');
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -182,7 +182,8 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         $applicationConfig = $this->getApplicationConfig();
 
         $applicationConfig['modules'][] = 'ModuleWithNamespace\TestModule';
-        $applicationConfig['module_listener_options']['module_paths']['ModuleWithNamespace\TestModule'] = __DIR__ . '/../../_files/ModuleWithNamespace/TestModule/';
+        $applicationConfig['module_listener_options']['module_paths']['ModuleWithNamespace\TestModule']
+            = __DIR__ . '/../../_files/ModuleWithNamespace/TestModule/';
 
         $this->setApplicationConfig($applicationConfig);
 

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -177,7 +177,7 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
     }
 
     /** @return void */
-    public function testAssertModulNameWithNamespace()
+    public function testAssertModuleNameWithNamespace()
     {
         $applicationConfig = $this->getApplicationConfig();
 

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -495,7 +495,7 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
     /**
      * @group 6399
      */
-    public function testPatchRequestParams()
+    public function testPatchRequestParams(): void
     {
         $this->dispatch('/tests', 'PATCH', ['a' => 1]);
         $this->assertEquals('a=1', $this->getRequest()->getContent());
@@ -504,7 +504,7 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
     /**
      * @group 6399
      */
-    public function testPreserveContentOfPatchRequest()
+    public function testPreserveContentOfPatchRequest(): void
     {
         $this->getRequest()->setMethod('PATCH');
         $this->getRequest()->setContent('my content');
@@ -512,7 +512,7 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertEquals('my content', $this->getRequest()->getContent());
     }
 
-    public function testExplicityPutParamsOverrideRequestContent()
+    public function testExplicityPutParamsOverrideRequestContent(): void
     {
         $this->getRequest()->setContent('my content');
         $this->dispatch('/tests', 'PUT', ['a' => 1]);
@@ -523,13 +523,13 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
      * @group 6636
      * @group 6637
      */
-    public function testCanHandleMultidimensionalParams()
+    public function testCanHandleMultidimensionalParams(): void
     {
         $this->dispatch('/tests', 'PUT', ['a' => ['b' => 1]]);
         $this->assertEquals('a[b]=1', urldecode($this->getRequest()->getContent()));
     }
 
-    public function testAssertTemplateName()
+    public function testAssertTemplateName(): void
     {
         $this->dispatch('/tests');
 
@@ -537,20 +537,20 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertTemplateName('baz/index/unittests');
     }
 
-    public function testAssertNotTemplateName()
+    public function testAssertNotTemplateName(): void
     {
         $this->dispatch('/tests');
 
         $this->assertNotTemplateName('template/does/not/exist');
     }
 
-    public function testCustomResponseObject()
+    public function testCustomResponseObject(): void
     {
         $this->dispatch('/custom-response');
         $this->assertResponseStatusCode(999);
     }
 
-    public function testResetDoesNotCreateSessionIfNoSessionExists()
+    public function testResetDoesNotCreateSessionIfNoSessionExists(): void
     {
         if (! extension_loaded('session')) {
             $this->markTestSkipped('No session extension loaded');
@@ -561,8 +561,10 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertFalse(array_key_exists('_SESSION', $GLOBALS));
     }
 
-    /** @return array<string, array<string|null>> */
-    public function method(): iterable
+    /**
+     * @psalm-return Generator<string, array{0: null|string}, mixed, void>
+     */
+    public function method(): Generator
     {
         yield 'null' => [null];
         yield 'get' => ['GET'];
@@ -576,13 +578,13 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
      * @dataProvider method
      * @param null|string $method
      */
-    public function testDispatchWithNullParams($method)
+    public function testDispatchWithNullParams($method): void
     {
         $this->dispatch('/custom-response', $method, null);
         $this->assertResponseStatusCode(999);
     }
 
-    public function testQueryParamsDelete()
+    public function testQueryParamsDelete(): void
     {
         $this->dispatch('/tests', 'DELETE', ['foo' => 'bar']);
         $this->assertEquals('foo=bar', $this->getRequest()->getQuery()->toString());
@@ -601,13 +603,13 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
      * @dataProvider routeParam
      * @param string $param
      */
-    public function testRequestWithRouteParam($param)
+    public function testRequestWithRouteParam($param): void
     {
         $this->dispatch(sprintf('/with-param/%s', $param));
         $this->assertResponseStatusCode(200);
     }
 
-    private function assertContainsCompat(string $needle, string $haystack)
+    private function assertContainsCompat(string $needle, string $haystack): void
     {
         if (method_exists($this, 'assertStringContainsString')) {
             $this->assertStringContainsString($needle, $haystack);
@@ -616,7 +618,7 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         }
     }
 
-    private function assertNotContainsCompat(string $needle, string $haystack)
+    private function assertNotContainsCompat(string $needle, string $haystack): void
     {
         if (method_exists($this, 'assertStringNotContainsString')) {
             $this->assertStringNotContainsString($needle, $haystack);

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -177,6 +177,20 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
     }
 
     /** @return void */
+    public function testAssertModulNameWithNamespace()
+    {
+        $applicationConfig = $this->getApplicationConfig();
+
+        $applicationConfig['modules'][] = 'ModuleWithNamespace\TestModule';
+        $applicationConfig['module_listener_options']['module_paths']['ModuleWithNamespace\TestModule'] = __DIR__ . '/../../_files/ModuleWithNamespace/TestModule/';
+
+        $this->setApplicationConfig($applicationConfig);
+
+        $this->dispatch('/namespace-test');
+        $this->assertModuleName('TestModule');
+    }
+
+    /** @return void */
     public function testAssertExceptionDetailsPresentWhenTraceErrorIsEnabled()
     {
         $this->traceError = true;

--- a/test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -37,12 +37,12 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         parent::setUp();
     }
 
-    public function testUseOfRouter()
+    public function testUseOfRouter(): void
     {
         $this->assertEquals(false, $this->useConsoleRequest);
     }
 
-    public function testAssertResponseStatusCode()
+    public function testAssertResponseStatusCode(): void
     {
         $this->dispatch('/tests');
         $this->assertResponseStatusCode(200);
@@ -54,7 +54,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertResponseStatusCode(302);
     }
 
-    public function testAssertNotResponseStatusCode()
+    public function testAssertNotResponseStatusCode(): void
     {
         $this->dispatch('/tests');
         $this->assertNotResponseStatusCode(302);
@@ -63,7 +63,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotResponseStatusCode(200);
     }
 
-    public function testAssertHasResponseHeader()
+    public function testAssertHasResponseHeader(): void
     {
         $this->dispatch('/tests');
         $this->assertHasResponseHeader('Content-Type');
@@ -72,7 +72,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertHasResponseHeader('Unknow-header');
     }
 
-    public function testAssertNotHasResponseHeader()
+    public function testAssertNotHasResponseHeader(): void
     {
         $this->dispatch('/tests');
         $this->assertNotHasResponseHeader('Unknow-header');
@@ -81,7 +81,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotHasResponseHeader('Content-Type');
     }
 
-    public function testAssertResponseHeaderContains()
+    public function testAssertResponseHeaderContains(): void
     {
         $this->dispatch('/tests');
         $this->assertResponseHeaderContains('Content-Type', 'text/html');
@@ -93,13 +93,13 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertResponseHeaderContains('Content-Type', 'text/json');
     }
 
-    public function testAssertResponseHeaderContainsMultipleHeaderInterface()
+    public function testAssertResponseHeaderContainsMultipleHeaderInterface(): void
     {
         $this->dispatch('/tests');
         $this->assertResponseHeaderContains('WWW-Authenticate', 'Basic realm="Laminas"');
     }
 
-    public function testAssertNotResponseHeaderContains()
+    public function testAssertNotResponseHeaderContains(): void
     {
         $this->dispatch('/tests');
         $this->assertNotResponseHeaderContains('Content-Type', 'text/json');
@@ -108,13 +108,13 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotResponseHeaderContains('Content-Type', 'text/html');
     }
 
-    public function testAssertNotResponseHeaderContainsMultipleHeaderInterface()
+    public function testAssertNotResponseHeaderContainsMultipleHeaderInterface(): void
     {
         $this->dispatch('/tests');
         $this->assertNotResponseHeaderContains('WWW-Authenticate', 'Basic realm="LaminasProject"');
     }
 
-    public function testAssertResponseHeaderRegex()
+    public function testAssertResponseHeaderRegex(): void
     {
         $this->dispatch('/tests');
         $this->assertResponseHeaderRegex('Content-Type', '#html$#');
@@ -126,13 +126,13 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertResponseHeaderRegex('Content-Type', '#json#');
     }
 
-    public function testAssertResponseHeaderRegexMultipleHeaderInterface()
+    public function testAssertResponseHeaderRegexMultipleHeaderInterface(): void
     {
         $this->dispatch('/tests');
         $this->assertResponseHeaderRegex('WWW-Authenticate', '#"Laminas"$#');
     }
 
-    public function testAssertNotResponseHeaderRegex()
+    public function testAssertNotResponseHeaderRegex(): void
     {
         $this->dispatch('/tests');
         $this->assertNotResponseHeaderRegex('Content-Type', '#json#');
@@ -141,13 +141,13 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotResponseHeaderRegex('Content-Type', '#html$#');
     }
 
-    public function testAssertNotResponseHeaderRegexMultipleHeaderInterface()
+    public function testAssertNotResponseHeaderRegexMultipleHeaderInterface(): void
     {
         $this->dispatch('/tests');
         $this->assertNotResponseHeaderRegex('WWW-Authenticate', '#"LaminasProject"$#');
     }
 
-    public function testAssertRedirect()
+    public function testAssertRedirect(): void
     {
         $this->dispatch('/redirect');
         $this->assertRedirect();
@@ -159,7 +159,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotRedirect();
     }
 
-    public function testAssertNotRedirect()
+    public function testAssertNotRedirect(): void
     {
         $this->dispatch('/test');
         $this->assertNotRedirect();
@@ -168,7 +168,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertRedirect();
     }
 
-    public function testAssertRedirectTo()
+    public function testAssertRedirectTo(): void
     {
         $this->dispatch('/redirect');
         $this->assertRedirectTo('https://www.zend.com');
@@ -180,7 +180,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertRedirectTo('http://www.laminas.fr');
     }
 
-    public function testAssertNotRedirectTo()
+    public function testAssertNotRedirectTo(): void
     {
         $this->dispatch('/redirect');
         $this->assertNotRedirectTo('http://www.laminas.fr');
@@ -189,7 +189,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotRedirectTo('https://www.zend.com');
     }
 
-    public function testAssertRedirectRegex()
+    public function testAssertRedirectRegex(): void
     {
         $this->dispatch('/redirect');
         $this->assertRedirectRegex('#zend\.com$#');
@@ -201,7 +201,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertRedirectRegex('#laminas\.fr$#');
     }
 
-    public function testAssertNotRedirectRegex()
+    public function testAssertNotRedirectRegex(): void
     {
         $this->dispatch('/redirect');
         $this->assertNotRedirectRegex('#laminas\.fr#');
@@ -210,7 +210,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotRedirectRegex('#zend\.com$#');
     }
 
-    public function testAssertQuery()
+    public function testAssertQuery(): void
     {
         $this->dispatch('/tests');
         $this->assertQuery('form#myform');
@@ -219,7 +219,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQuery('form#id');
     }
 
-    public function testAssertXpathQuery()
+    public function testAssertXpathQuery(): void
     {
         $this->dispatch('/tests');
         $this->assertXpathQuery('//form[@id="myform"]');
@@ -228,7 +228,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQuery('//form[@id="id"]');
     }
 
-    public function testAssertXpathQueryWithBadXpathUsage()
+    public function testAssertXpathQueryWithBadXpathUsage(): void
     {
         $this->dispatch('/tests');
 
@@ -236,7 +236,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQuery('form#myform');
     }
 
-    public function testAssertNotQuery()
+    public function testAssertNotQuery(): void
     {
         $this->dispatch('/tests');
         $this->assertNotQuery('form#id');
@@ -245,7 +245,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotQuery('form#myform');
     }
 
-    public function testAssertNotXpathQuery()
+    public function testAssertNotXpathQuery(): void
     {
         $this->dispatch('/tests');
         $this->assertNotXpathQuery('//form[@id="id"]');
@@ -254,7 +254,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotXpathQuery('//form[@id="myform"]');
     }
 
-    public function testAssertQueryCount()
+    public function testAssertQueryCount(): void
     {
         $this->dispatch('/tests');
         $this->assertQueryCount('div.top', 3);
@@ -266,7 +266,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQueryCount('div.top', 2);
     }
 
-    public function testAssertXpathQueryCount()
+    public function testAssertXpathQueryCount(): void
     {
         $this->dispatch('/tests');
         $this->assertXpathQueryCount('//div[@class="top"]', 3);
@@ -278,13 +278,13 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCount('//div[@class="top"]', 2);
     }
 
-    public function testAssertXpathQueryCountWithBadXpathUsage()
+    public function testAssertXpathQueryCountWithBadXpathUsage(): void
     {
         $this->dispatch('/tests');
         $this->assertXpathQueryCount('div.top', 0);
     }
 
-    public function testAssertNotQueryCount()
+    public function testAssertNotQueryCount(): void
     {
         $this->dispatch('/tests');
         $this->assertNotQueryCount('div.top', 1);
@@ -294,7 +294,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotQueryCount('div.top', 3);
     }
 
-    public function testAssertNotXpathQueryCount()
+    public function testAssertNotXpathQueryCount(): void
     {
         $this->dispatch('/tests');
         $this->assertNotXpathQueryCount('//div[@class="top"]', 1);
@@ -304,7 +304,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotXpathQueryCount('//div[@class="top"]', 3);
     }
 
-    public function testAssertQueryCountMin()
+    public function testAssertQueryCountMin(): void
     {
         $this->dispatch('/tests');
         $this->assertQueryCountMin('div.top', 1);
@@ -318,7 +318,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQueryCountMin('div.top', 4);
     }
 
-    public function testAssertXpathQueryCountMin()
+    public function testAssertXpathQueryCountMin(): void
     {
         $this->dispatch('/tests');
         $this->assertXpathQueryCountMin('//div[@class="top"]', 1);
@@ -332,7 +332,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCountMin('//div[@class="top"]', 4);
     }
 
-    public function testAssertQueryCountMax()
+    public function testAssertQueryCountMax(): void
     {
         $this->dispatch('/tests');
         $this->assertQueryCountMax('div.top', 5);
@@ -346,7 +346,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQueryCountMax('div.top', 2);
     }
 
-    public function testAssertXpathQueryCountMax()
+    public function testAssertXpathQueryCountMax(): void
     {
         $this->dispatch('/tests');
         $this->assertXpathQueryCountMax('//div[@class="top"]', 5);
@@ -360,7 +360,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCountMax('//div[@class="top"]', 2);
     }
 
-    public function testAssertQueryContentContains()
+    public function testAssertQueryContentContains(): void
     {
         $this->dispatch('/tests');
         $this->assertQueryContentContains('div#content', 'foo');
@@ -371,7 +371,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQueryContentContains('div#content', 'bar');
     }
 
-    public function testAssertQueryContentContainsWithSecondElement()
+    public function testAssertQueryContentContainsWithSecondElement(): void
     {
         $this->dispatch('/tests');
         $this->assertQueryContentContains('div#content', 'foo');
@@ -382,7 +382,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQueryContentContains('div.top', 'bar');
     }
 
-    public function testAssertXpathQueryContentContains()
+    public function testAssertXpathQueryContentContains(): void
     {
         $this->dispatch('/tests');
         $this->assertXpathQueryContentContains('//div[@class="top"]', 'foo');
@@ -393,7 +393,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryContentContains('//div[@class="top"]', 'bar');
     }
 
-    public function testAssertNotQueryContentContains()
+    public function testAssertNotQueryContentContains(): void
     {
         $this->dispatch('/tests');
         $this->assertNotQueryContentContains('div#content', 'bar');
@@ -402,7 +402,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotQueryContentContains('div#content', 'foo');
     }
 
-    public function testAssertNotXpathQueryContentContains()
+    public function testAssertNotXpathQueryContentContains(): void
     {
         $this->dispatch('/tests');
         $this->assertNotXpathQueryContentContains('//div[@id="content"]', 'bar');
@@ -411,7 +411,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotXpathQueryContentContains('//div[@id="content"]', 'foo');
     }
 
-    public function testAssertQueryContentRegex()
+    public function testAssertQueryContentRegex(): void
     {
         $this->dispatch('/tests');
         $this->assertQueryContentRegex('div#content', '#o{2}#');
@@ -423,7 +423,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQueryContentRegex('div#content', '#o{3,}#');
     }
 
-    public function testAssertQueryContentRegexMultipleMatches()
+    public function testAssertQueryContentRegexMultipleMatches(): void
     {
         $this->dispatch('/tests');
         $this->assertQueryContentRegex('div.top', '#o{2}#');
@@ -435,7 +435,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQueryContentRegex('div.top', '#o{3,}#');
     }
 
-    public function testAssertQueryContentRegexMultipleMatchesNoFalsePositive()
+    public function testAssertQueryContentRegexMultipleMatchesNoFalsePositive(): void
     {
         $this->dispatch('/tests');
 
@@ -446,7 +446,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQueryContentRegex('div', '/foobar/');
     }
 
-    public function testAssertXpathQueryContentRegex()
+    public function testAssertXpathQueryContentRegex(): void
     {
         $this->dispatch('/tests');
         $this->assertXpathQueryContentRegex('//div[@id="content"]', '#o{2}#');
@@ -458,7 +458,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryContentRegex('//div[@id="content"]', '#o{3,}#');
     }
 
-    public function testAssertNotQueryContentRegex()
+    public function testAssertNotQueryContentRegex(): void
     {
         $this->dispatch('/tests');
         $this->assertNotQueryContentRegex('div#content', '#o{3,}#');
@@ -467,7 +467,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotQueryContentRegex('div#content', '#o{2}#');
     }
 
-    public function testAssertNotXpathQueryContentRegex()
+    public function testAssertNotXpathQueryContentRegex(): void
     {
         $this->dispatch('/tests');
         $this->assertNotXpathQueryContentRegex('//div[@id="content"]', '#o{3,}#');
@@ -476,7 +476,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotXpathQueryContentRegex('//div[@id="content"]', '#o{2}#');
     }
 
-    public function testAssertQueryWithDynamicQueryParams()
+    public function testAssertQueryWithDynamicQueryParams(): void
     {
         $this->getRequest()
             ->setMethod('GET')
@@ -488,7 +488,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCount('//div[@class="post"]', 0);
     }
 
-    public function testAssertQueryWithDynamicQueryParamsInDispatchMethod()
+    public function testAssertQueryWithDynamicQueryParamsInDispatchMethod(): void
     {
         $this->dispatch('/tests', 'GET', ['num_get' => 5]);
         $this->assertQueryCount('div.get', 5);
@@ -497,7 +497,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCount('//div[@class="post"]', 0);
     }
 
-    public function testAssertQueryWithDynamicQueryParamsInUrl()
+    public function testAssertQueryWithDynamicQueryParamsInUrl(): void
     {
         $this->dispatch('/tests?foo=bar&num_get=5');
         $this->assertQueryCount('div.get', 5);
@@ -506,7 +506,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCount('//div[@class="post"]', 0);
     }
 
-    public function testAssertQueryWithDynamicQueryParamsInUrlAnsPostInParams()
+    public function testAssertQueryWithDynamicQueryParamsInUrlAnsPostInParams(): void
     {
         $this->dispatch('/tests?foo=bar&num_get=5', 'POST', ['num_post' => 5]);
         $this->assertQueryCount('div.get', 5);
@@ -515,7 +515,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCount('//div[@class="post"]', 5);
     }
 
-    public function testAssertQueryWithDynamicPostParams()
+    public function testAssertQueryWithDynamicPostParams(): void
     {
         $this->getRequest()
             ->setMethod('POST')
@@ -527,7 +527,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCount('//div[@class="get"]', 0);
     }
 
-    public function testAssertQueryWithDynamicPostParamsInDispatchMethod()
+    public function testAssertQueryWithDynamicPostParamsInDispatchMethod(): void
     {
         $this->dispatch('/tests', 'POST', ['num_post' => 5]);
         $request = $this->getRequest();
@@ -538,7 +538,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCount('//div[@class="get"]', 0);
     }
 
-    public function testAssertQueryWithDynamicPutParamsInDispatchMethod()
+    public function testAssertQueryWithDynamicPutParamsInDispatchMethod(): void
     {
         $this->dispatch('/tests', 'PUT', ['num_post' => 5, 'foo' => 'bar']);
         $request = $this->getRequest();
@@ -546,7 +546,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertEquals('num_post=5&foo=bar', $request->getContent());
     }
 
-    public function testAssertUriWithHostname()
+    public function testAssertUriWithHostname(): void
     {
         $this->dispatch('http://my.domain.tld:443');
         $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
@@ -554,7 +554,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertEquals($this->getRequest()->getUri()->getPort(), 443);
     }
 
-    public function testAssertWithMultiDispatch()
+    public function testAssertWithMultiDispatch(): void
     {
         $this->dispatch('/tests');
         $this->assertQueryCount('div.get', 0);
@@ -579,7 +579,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCount('//div[@class="post"]', 0);
     }
 
-    public function testAssertWithMultiDispatchWithoutPersistence()
+    public function testAssertWithMultiDispatchWithoutPersistence(): void
     {
         if (! extension_loaded('session')) {
             $this->markTestSkipped('No session extension loaded');
@@ -607,7 +607,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertCount(0, $messages);
     }
 
-    public function testAssertWithMultiDispatchWithPersistence()
+    public function testAssertWithMultiDispatchWithPersistence(): void
     {
         if (! extension_loaded('session')) {
             $this->markTestSkipped('No session extension loaded');
@@ -635,7 +635,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertCount(1, $messages);
     }
 
-    public function testAssertWithEventShared()
+    public function testAssertWithEventShared(): void
     {
         if (! class_exists(StaticEventManager::class)) {
             $this->markTestSkipped(
@@ -673,7 +673,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertNotEquals('<html></html>', $this->getResponse()->getContent());
     }
 
-    public function testAssertExceptionInAction()
+    public function testAssertExceptionInAction(): void
     {
         $this->setTraceError(true);
 
@@ -682,14 +682,14 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertApplicationException('RuntimeException');
     }
 
-    public function testAssertExceptionAndMessageInAction()
+    public function testAssertExceptionAndMessageInAction(): void
     {
         $this->dispatch('/exception');
         $this->assertResponseStatusCode(500);
         $this->assertApplicationException('RuntimeException', 'Foo error');
     }
 
-    public function testTraceErrorEnableByDefault()
+    public function testTraceErrorEnableByDefault(): void
     {
         $this->dispatch('/exception');
         $this->assertResponseStatusCode(500);
@@ -704,7 +704,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         }
     }
 
-    public function testGetErrorWithTraceErrorEnabled()
+    public function testGetErrorWithTraceErrorEnabled(): void
     {
         $this->dispatch('/exception');
         $this->assertResponseStatusCode(500);
@@ -719,7 +719,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
     /**
      * Sample tests on MvcEvent
      */
-    public function testAssertApplicationMvcEvent()
+    public function testAssertApplicationMvcEvent(): void
     {
         $this->dispatch('/tests');
 
@@ -745,7 +745,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
     /**
      * Sample tests on Application events
      */
-    public function testAssertApplicationEvents()
+    public function testAssertApplicationEvents(): void
     {
         $this->url('/tests');
 
@@ -756,13 +756,13 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertEquals(true, $routeMatch instanceof RouteMatch);
         $this->assertEquals($routeMatch->getParam('controller'), 'baz_index');
 
-        $result    = $this->triggerApplicationEvent(MvcEvent::EVENT_DISPATCH);
+        $this->triggerApplicationEvent(MvcEvent::EVENT_DISPATCH);
         $viewModel = $this->getApplication()->getMvcEvent()->getResult();
         $this->assertEquals(true, $viewModel instanceof ViewModel);
         $this->assertEquals($viewModel->getTemplate(), 'baz/index/unittests');
     }
 
-    public function testAssertResponseReasonPhrase()
+    public function testAssertResponseReasonPhrase(): void
     {
         $this->dispatch('/tests');
         $this->assertResponseReasonPhrase('OK');
@@ -771,7 +771,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertResponseReasonPhrase('NOT OK');
     }
 
-    public function testAssertXmlHttpRequestDispatch()
+    public function testAssertXmlHttpRequestDispatch(): void
     {
         $request = $this->getRequest();
         $this->assertFalse($request->isXmlHttpRequest());

--- a/test/PHPUnit/ModuleDependenciesTest.php
+++ b/test/PHPUnit/ModuleDependenciesTest.php
@@ -13,7 +13,7 @@ class ModuleDependenciesTest extends AbstractHttpControllerTestCase
 {
     use ExpectedExceptionTrait;
 
-    public function testDependenciesModules()
+    public function testDependenciesModules(): void
     {
         $this->setApplicationConfig(
             include __DIR__ . '/../_files/application.config.with.dependencies.php'
@@ -27,7 +27,7 @@ class ModuleDependenciesTest extends AbstractHttpControllerTestCase
         $this->assertModulesLoaded(['Foo', 'Bar', 'Unknow']);
     }
 
-    public function testBadDependenciesModules()
+    public function testBadDependenciesModules(): void
     {
         $this->setApplicationConfig(
             include __DIR__ . '/../_files/application.config.with.dependencies.disabled.php'

--- a/test/PHPUnit/Util/ModuleLoaderTest.php
+++ b/test/PHPUnit/Util/ModuleLoaderTest.php
@@ -66,6 +66,16 @@ class ModuleLoaderTest extends TestCase
     }
 
     /** @return void */
+    public function testCanLoadModuleWithNamespace()
+    {
+        $loader = new ModuleLoader(['ModuleWithNamespace\TestModule' => __DIR__ . '/../../_files/ModuleWithNamespace/TestModule']);
+        $testModule = $loader->getModule('ModuleWithNamespace\TestModule');
+
+        $this->assertInstanceOf('ModuleWithNamespace\TestModule\Module', $testModule);
+        $this->assertInstanceOf(\ModuleWithNamespace\TestModule\Module::class, $testModule);
+    }
+
+    /** @return void */
     public function testCanNotLoadModule()
     {
         $this->expectedException(RuntimeException::class, 'could not be initialized');

--- a/test/PHPUnit/Util/ModuleLoaderTest.php
+++ b/test/PHPUnit/Util/ModuleLoaderTest.php
@@ -68,7 +68,10 @@ class ModuleLoaderTest extends TestCase
     /** @return void */
     public function testCanLoadModuleWithNamespace()
     {
-        $loader = new ModuleLoader(['ModuleWithNamespace\TestModule' => __DIR__ . '/../../_files/ModuleWithNamespace/TestModule']);
+        $loader = new ModuleLoader([
+            'ModuleWithNamespace\TestModule' => __DIR__ . '/../../_files/ModuleWithNamespace/TestModule'
+        ]);
+
         $testModule = $loader->getModule('ModuleWithNamespace\TestModule');
 
         $this->assertInstanceOf('ModuleWithNamespace\TestModule\Module', $testModule);

--- a/test/PHPUnit/Util/ModuleLoaderTest.php
+++ b/test/PHPUnit/Util/ModuleLoaderTest.php
@@ -12,6 +12,7 @@ use Laminas\Mvc\ApplicationInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Test\Util\ModuleLoader;
 use LaminasTest\Test\ExpectedExceptionTrait;
+use ModuleWithNamespace\TestModule\Module;
 use PHPUnit\Framework\TestCase;
 
 use function array_diff;
@@ -69,20 +70,20 @@ class ModuleLoaderTest extends TestCase
     public function testCanLoadModuleWithNamespace()
     {
         $loader = new ModuleLoader([
-            'ModuleWithNamespace\TestModule' => __DIR__ . '/../../_files/ModuleWithNamespace/TestModule'
+            'ModuleWithNamespace\TestModule' => __DIR__ . '/../../_files/ModuleWithNamespace/TestModule',
         ]);
 
         $testModule = $loader->getModule('ModuleWithNamespace\TestModule');
 
         $this->assertInstanceOf('ModuleWithNamespace\TestModule\Module', $testModule);
-        $this->assertInstanceOf(\ModuleWithNamespace\TestModule\Module::class, $testModule);
+        $this->assertInstanceOf(Module::class, $testModule);
     }
 
     /** @return void */
     public function testCanNotLoadModule()
     {
         $this->expectedException(RuntimeException::class, 'could not be initialized');
-        $loader = new ModuleLoader(['FooBaz']);
+        new ModuleLoader(['FooBaz']);
     }
 
     /** @return void */

--- a/test/_files/ModuleWithNamespace/TestModule/Module.php
+++ b/test/_files/ModuleWithNamespace/TestModule/Module.php
@@ -2,23 +2,30 @@
 
 /**
  * @see       https://github.com/laminas/laminas-test for the canonical source repository
- * @copyright https://github.com/laminas/laminas-test/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-test/blob/master/LICENSE.md New BSD License
  */
 
 namespace ModuleWithNamespace\TestModule;
 
+use Laminas\Loader\StandardAutoloader;
+
 class Module
 {
-    public function getConfig()
+    /**
+     * @psalm-return array<string, mixed>
+     */
+    public function getConfig(): array
     {
         return include __DIR__ . '/config/module.config.php';
     }
 
-    public function getAutoloaderConfig()
+    /**
+     * @return string[][][]
+     * @psalm-return array<string, array<string, array<string, string>>>
+     */
+    public function getAutoloaderConfig(): array
     {
         return [
-            'Laminas\Loader\StandardAutoloader' => [
+            StandardAutoloader::class => [
                 'namespaces' => [
                     __NAMESPACE__ => __DIR__ . '/src/',
                 ],

--- a/test/_files/ModuleWithNamespace/TestModule/Module.php
+++ b/test/_files/ModuleWithNamespace/TestModule/Module.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-test for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-test/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-test/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ModuleWithNamespace\TestModule;
+
+class Module
+{
+    public function getConfig()
+    {
+        return include __DIR__ . '/config/module.config.php';
+    }
+
+    public function getAutoloaderConfig()
+    {
+        return [
+            'Laminas\Loader\StandardAutoloader' => [
+                'namespaces' => [
+                    __NAMESPACE__ => __DIR__ . '/src/',
+                ],
+            ],
+        ];
+    }
+}

--- a/test/_files/ModuleWithNamespace/TestModule/config/module.config.php
+++ b/test/_files/ModuleWithNamespace/TestModule/config/module.config.php
@@ -1,0 +1,22 @@
+<?php
+return [
+    'router' => [
+        'routes' => [
+            'namespace_route' => [
+                'type' => 'literal',
+                'options' => [
+                    'route'    => '/namespace-test',
+                    'defaults' => [
+                        'controller' => 'namespace_index',
+                        'action'     => 'unittests',
+                    ],
+                ],
+            ],
+        ],
+    ],
+    'controllers' => [
+        'invokables' => [
+            'namespace_index' => 'ModuleWithNamespace\TestModule\Controller\IndexController',
+        ],
+    ],
+];

--- a/test/_files/ModuleWithNamespace/TestModule/config/module.config.php
+++ b/test/_files/ModuleWithNamespace/TestModule/config/module.config.php
@@ -1,9 +1,10 @@
 <?php
+
 return [
-    'router' => [
+    'router'      => [
         'routes' => [
             'namespace_route' => [
-                'type' => 'literal',
+                'type'    => 'literal',
                 'options' => [
                     'route'    => '/namespace-test',
                     'defaults' => [

--- a/test/_files/ModuleWithNamespace/TestModule/src/Controller/IndexController.php
+++ b/test/_files/ModuleWithNamespace/TestModule/src/Controller/IndexController.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/laminas/laminas-test for the canonical source repository
- * @copyright https://github.com/laminas/laminas-test/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-test/blob/master/LICENSE.md New BSD License
  */
 
 namespace ModuleWithNamespace\TestModule\Controller;
@@ -12,7 +10,7 @@ use Laminas\Mvc\Controller\AbstractActionController;
 
 class IndexController extends AbstractActionController
 {
-    public function unittestsAction()
+    public function unittestsAction(): string
     {
         return 'unittest';
     }

--- a/test/_files/ModuleWithNamespace/TestModule/src/Controller/IndexController.php
+++ b/test/_files/ModuleWithNamespace/TestModule/src/Controller/IndexController.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-test for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-test/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-test/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ModuleWithNamespace\TestModule\Controller;
+
+use Laminas\Mvc\Controller\AbstractActionController;
+
+class IndexController extends AbstractActionController
+{
+    public function unittestsAction()
+    {
+        return 'unittest';
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes (#20)

### Description

In this merge request, the current behavior is represented by a test case.

A module that lies within a namespace with more than 1 level is not correctly checked by the "assertModuleName".


fixes #20 