### PR TITLE
not counted as an assertion by PHPUnit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#24](https://github.com/laminas/laminas-test/pull/24) When `AbstractControllerTestCase::assertResponseStatusCode` fails it is not counted as an assertion by PHPUnit
 
 ## 3.4.2 - 2020-05-20
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

this pull request will fixes #6. As already described in the issue, the correct number of phpunit assertions is not counted in a Laminas assertion - if they fail and throw an exception too early. I'm not sure how to test this behavior with phpunit itself, but I'll try to find a way to validate this behavior in a test.