### PR TITLE
Test against PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,17 @@
     "extra": {
     },
     "require": {
-        "php": "^7.3 || ^7.4",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-console": "^2.6",
         "laminas/laminas-dom": "^2.8",
-        "laminas/laminas-eventmanager": "^2.6.2 || ^3.0",
-        "laminas/laminas-http": "^2.8.3",
+        "laminas/laminas-eventmanager": "^3.0",
+        "laminas/laminas-http": "^2.13",
         "laminas/laminas-mvc": "^3.0",
-        "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
+        "laminas/laminas-servicemanager": "^3.0.3",
         "laminas/laminas-stdlib": "^3.3",
         "laminas/laminas-uri": "^2.5",
         "laminas/laminas-view": "^2.6.3",
-        "laminas/laminas-zendframework-bridge": "^1.0",
+        "laminas/laminas-zendframework-bridge": "^1.1",
         "vimeo/psalm": "^4.7.0",
         "psalm/plugin-phpunit": "^0.15.0",
         "phpunit/phpunit": "^8.0 || ^9.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf9d0a84ca97351e389742c5a26c5254",
+    "content-hash": "0cb1df0437c1deabfcf14f5f6a0ae7d0",
     "packages": [
         {
             "name": "amphp/amp",
@@ -6062,7 +6062,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ^7.4"
+        "php": "^7.3 || ~8.0.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"


### PR DESCRIPTION
- Adds 8.0.0 to the PHP version constraint
- Removes old contstraints from eventmanager, servicemanager, and others where laminas-mvc v3 releases no longer support the older versions anyways.

This is mainly to trigger builds against 8.0 to ensure they run.
