### PR TITLE
Fixes wrong module name recognation in 3.5.0

### DIFF
--- a/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
+++ b/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
@@ -40,7 +40,7 @@ final class IsCurrentModuleNameConstraint extends LaminasConstraint
 
         // Find Module from Controller
         foreach ($applicationConfig['modules'] as $appModules) {
-            if (strpos($controllerClass, $appModules) !== false) {
+            if (strpos($controllerClass, $appModules.'\\') !== false) {
                 if (strpos($appModules, '\\') !== false) {
                     $match = ltrim(substr($appModules, strrpos($appModules, '\\')), '\\');
                 } else {

--- a/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
+++ b/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
@@ -40,7 +40,7 @@ final class IsCurrentModuleNameConstraint extends LaminasConstraint
 
         // Find Module from Controller
         foreach ($applicationConfig['modules'] as $appModules) {
-            if (strpos($controllerClass, $appModules.'\\') !== false) {
+            if (strpos($controllerClass, $appModules . '\\') !== false) {
                 if (strpos($appModules, '\\') !== false) {
                     $match = ltrim(substr($appModules, strrpos($appModules, '\\')), '\\');
                 } else {

--- a/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
+++ b/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
@@ -39,6 +39,7 @@ final class IsCurrentModuleNameConstraint extends LaminasConstraint
         $applicationConfig = $this->getTestCase()->getApplicationConfig();
 
         // Find Module from Controller
+        /** @var string $appModules */
         foreach ($applicationConfig['modules'] as $appModules) {
             if (strpos($controllerClass, $appModules . '\\') !== false) {
                 if (strpos($appModules, '\\') !== false) {

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -193,6 +193,24 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
     }
 
     /** @return void */
+    public function testAssertModuleWithSimilarName()
+    {
+        $applicationConfig = $this->getApplicationConfig();
+
+        $applicationConfig['modules'][] = 'ModuleWithSimilarName\TestModule';
+        $applicationConfig['modules'][] = 'ModuleWithSimilarName\Test';
+        $applicationConfig['module_listener_options']['module_paths']['ModuleWithSimilarName\TestModule']
+            = __DIR__ . '/../../_files/ModuleWithSimilarName/TestModule/';
+        $applicationConfig['module_listener_options']['module_paths']['ModuleWithSimilarName\Test']
+            = __DIR__ . '/../../_files/ModuleWithSimilarName/Test/';
+
+        $this->setApplicationConfig($applicationConfig);
+
+        $this->dispatch('/similar-name-2-test');
+        $this->assertModuleName('TestModule');
+    }
+
+    /** @return void */
     public function testAssertExceptionDetailsPresentWhenTraceErrorIsEnabled()
     {
         $this->traceError = true;

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -24,6 +24,7 @@ use RuntimeException;
 
 use function array_diff;
 use function array_key_exists;
+use function array_merge_recursive;
 use function count;
 use function extension_loaded;
 use function get_class;
@@ -197,17 +198,20 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
     {
         $applicationConfig = $this->getApplicationConfig();
 
-        /** @var array $modules */
-        $modules = $applicationConfig['modules'];
-        $modules[] = 'ModuleWithSimilarName\TestModule';
-        $modules[] = 'ModuleWithSimilarName\Test';
+        $testConfig = [
+            'modules'                 => [
+                'ModuleWithSimilarName\TestModule',
+                'ModuleWithSimilarName\Test',
+            ],
+            'module_listener_options' => [
+                'module_paths' => [
+                    'ModuleWithSimilarName\TestModule' => __DIR__ . '/../../_files/ModuleWithSimilarName/TestModule/',
+                    'ModuleWithSimilarName\Test'       => __DIR__ . '/../../_files/ModuleWithSimilarName/Test/',
+                ],
+            ],
+        ];
 
-        /** @var array $modulePaths */
-        $modulePaths = $applicationConfig['module_listener_options']['module_paths'];
-        $modulePaths['ModuleWithSimilarName\TestModule'] = __DIR__ . '/../../_files/ModuleWithSimilarName/TestModule/';
-        $modulePaths['ModuleWithSimilarName\Test']       = __DIR__ . '/../../_files/ModuleWithSimilarName/Test/';
-
-        $this->setApplicationConfig($applicationConfig);
+        $this->setApplicationConfig(array_merge_recursive($testConfig, $applicationConfig));
 
         $this->dispatch('/similar-name-2-test');
         $this->assertModuleName('TestModule');

--- a/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -197,12 +197,15 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
     {
         $applicationConfig = $this->getApplicationConfig();
 
-        $applicationConfig['modules'][] = 'ModuleWithSimilarName\TestModule';
-        $applicationConfig['modules'][] = 'ModuleWithSimilarName\Test';
-        $applicationConfig['module_listener_options']['module_paths']['ModuleWithSimilarName\TestModule']
-            = __DIR__ . '/../../_files/ModuleWithSimilarName/TestModule/';
-        $applicationConfig['module_listener_options']['module_paths']['ModuleWithSimilarName\Test']
-            = __DIR__ . '/../../_files/ModuleWithSimilarName/Test/';
+        /** @var array $modules */
+        $modules = $applicationConfig['modules'];
+        $modules[] = 'ModuleWithSimilarName\TestModule';
+        $modules[] = 'ModuleWithSimilarName\Test';
+
+        /** @var array $modulePaths */
+        $modulePaths = $applicationConfig['module_listener_options']['module_paths'];
+        $modulePaths['ModuleWithSimilarName\TestModule'] = __DIR__ . '/../../_files/ModuleWithSimilarName/TestModule/';
+        $modulePaths['ModuleWithSimilarName\Test']       = __DIR__ . '/../../_files/ModuleWithSimilarName/Test/';
 
         $this->setApplicationConfig($applicationConfig);
 

--- a/test/_files/ModuleWithSimilarName/Test/Module.php
+++ b/test/_files/ModuleWithSimilarName/Test/Module.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-test for the canonical source repository
+ */
+
+namespace ModuleWithSimilarName\Test;
+
+use Laminas\Loader\StandardAutoloader;
+
+class Module
+{
+    /**
+     * @psalm-return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        return include __DIR__ . '/config/module.config.php';
+    }
+
+    /**
+     * @return string[][][]
+     * @psalm-return array<string, array<string, array<string, string>>>
+     */
+    public function getAutoloaderConfig(): array
+    {
+        return [
+            StandardAutoloader::class => [
+                'namespaces' => [
+                    __NAMESPACE__ => __DIR__ . '/src/',
+                ],
+            ],
+        ];
+    }
+}

--- a/test/_files/ModuleWithSimilarName/Test/config/module.config.php
+++ b/test/_files/ModuleWithSimilarName/Test/config/module.config.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'router'      => [
+        'routes' => [
+            'similar_name_route' => [
+                'type'    => 'literal',
+                'options' => [
+                    'route'    => '/similar-name-test',
+                    'defaults' => [
+                        'controller' => 'similar_name_index',
+                        'action'     => 'unittests',
+                    ],
+                ],
+            ],
+        ],
+    ],
+    'controllers' => [
+        'invokables' => [
+            'similar_name_index' => 'ModuleWithSimilarName\Test\Controller\IndexController',
+        ],
+    ],
+];

--- a/test/_files/ModuleWithSimilarName/Test/src/Controller/IndexController.php
+++ b/test/_files/ModuleWithSimilarName/Test/src/Controller/IndexController.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-test for the canonical source repository
+ */
+
+namespace ModuleWithSimilarName\Test\Controller;
+
+use Laminas\Mvc\Controller\AbstractActionController;
+
+class IndexController extends AbstractActionController
+{
+    public function unittestsAction(): string
+    {
+        return 'unittest';
+    }
+}

--- a/test/_files/ModuleWithSimilarName/TestModule/Module.php
+++ b/test/_files/ModuleWithSimilarName/TestModule/Module.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-test for the canonical source repository
+ */
+
+namespace ModuleWithSimilarName\TestModule;
+
+use Laminas\Loader\StandardAutoloader;
+
+class Module
+{
+    /**
+     * @psalm-return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        return include __DIR__ . '/config/module.config.php';
+    }
+
+    /**
+     * @return string[][][]
+     * @psalm-return array<string, array<string, array<string, string>>>
+     */
+    public function getAutoloaderConfig(): array
+    {
+        return [
+            StandardAutoloader::class => [
+                'namespaces' => [
+                    __NAMESPACE__ => __DIR__ . '/src/',
+                ],
+            ],
+        ];
+    }
+}

--- a/test/_files/ModuleWithSimilarName/TestModule/config/module.config.php
+++ b/test/_files/ModuleWithSimilarName/TestModule/config/module.config.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'router'      => [
+        'routes' => [
+            'similar_name_2_route' => [
+                'type'    => 'literal',
+                'options' => [
+                    'route'    => '/similar-name-2-test',
+                    'defaults' => [
+                        'controller' => 'similar_name_2_index',
+                        'action'     => 'unittests',
+                    ],
+                ],
+            ],
+        ],
+    ],
+    'controllers' => [
+        'invokables' => [
+            'similar_name_2_index' => 'ModuleWithSimilarName\TestModule\Controller\IndexController',
+        ],
+    ],
+];

--- a/test/_files/ModuleWithSimilarName/TestModule/src/Controller/IndexController.php
+++ b/test/_files/ModuleWithSimilarName/TestModule/src/Controller/IndexController.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-test for the canonical source repository
+ */
+
+namespace ModuleWithSimilarName\TestModule\Controller;
+
+use Laminas\Mvc\Controller\AbstractActionController;
+
+class IndexController extends AbstractActionController
+{
+    public function unittestsAction(): string
+    {
+        return 'unittest';
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
fixes #34 
Fixes a bug introduced in 3.5.0. In some cases module names were not recognized correctly.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

ping @nusphere 