### PR TITLE
Drop `laminas/laminas-zendframework-bridge` and `zendframework/*` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "laminas/laminas-stdlib": "^3.3",
         "laminas/laminas-uri": "^2.5",
         "laminas/laminas-view": "^2.6.3",
-        "laminas/laminas-zendframework-bridge": "^1.1",
         "phpunit/phpunit": "^8.4.3 || ^9.0",
         "symfony/css-selector": "^5.4 || ^6.0",
         "symfony/dom-crawler": "^5.4 || ^6.0"
@@ -68,7 +67,7 @@
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "static-analysis": "psalm --shepherd --stats"
     },
-    "replace": {
-        "zendframework/zend-test": "^3.3.0"
+    "conflict": {
+        "zendframework/zend-test": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cafde7fef8747781cbfeec3afc79d3e",
+    "content-hash": "33dd467a9ebdf8fc094723d29c93ae39",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -5929,5 +5929,5 @@
         "php": "^7.3 || ~8.0.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
