### PR TITLE
change conditions and use better assertion methods

### DIFF
--- a/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php
@@ -62,7 +62,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
                 $header
             )));
         }
-        $this->assertTrue($responseHeader);
+        $this->assertNotEquals(false, $responseHeader);
     }
 
     /**
@@ -80,7 +80,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
                 $header
             )));
         }
-        $this->assertFalse($responseHeader);
+        $this->assertEquals(false, $responseHeader);
     }
 
     /**
@@ -253,7 +253,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
                 'Failed asserting response is a redirect'
             ));
         }
-        $this->assertTrue($responseHeader);
+        $this->assertNotEquals(false, $responseHeader);
     }
 
     /**
@@ -270,7 +270,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
                 $responseHeader->getFieldValue()
             )));
         }
-        $this->assertFalse($responseHeader);
+        $this->assertEquals(false, $responseHeader);
     }
 
     /**

--- a/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php
+++ b/src/PHPUnit/Controller/AbstractHttpControllerTestCase.php
@@ -56,13 +56,13 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     public function assertHasResponseHeader($header)
     {
         $responseHeader = $this->getResponseHeader($header);
-        if (false === $responseHeader) {
+        if (! $responseHeader) {
             throw new ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response header "%s" found',
                 $header
             )));
         }
-        $this->assertNotEquals(false, $responseHeader);
+        $this->assertTrue($responseHeader);
     }
 
     /**
@@ -74,7 +74,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     public function assertNotHasResponseHeader($header)
     {
         $responseHeader = $this->getResponseHeader($header);
-        if (false !== $responseHeader) {
+        if ($responseHeader) {
             throw new ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response header "%s" WAS NOT found',
                 $header
@@ -248,12 +248,12 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     public function assertRedirect()
     {
         $responseHeader = $this->getResponseHeader('Location');
-        if (false === $responseHeader) {
+        if (! $responseHeader) {
             throw new ExpectationFailedException($this->createFailureMessage(
                 'Failed asserting response is a redirect'
             ));
         }
-        $this->assertNotEquals(false, $responseHeader);
+        $this->assertTrue($responseHeader);
     }
 
     /**
@@ -264,7 +264,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     public function assertNotRedirect()
     {
         $responseHeader = $this->getResponseHeader('Location');
-        if (false !== $responseHeader) {
+        if ($responseHeader) {
             throw new ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting response is NOT a redirect, actual redirection is "%s"',
                 $responseHeader->getFieldValue()
@@ -744,7 +744,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     {
         $result = $this->query($path, $useXpath);
 
-        if ($result->count() === 0) {
+        if (! $result->count()) {
             throw new ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s EXISTS',
                 $path
@@ -804,7 +804,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     private function notQueryContentContainsAssertion($path, $match, $useXpath = false): void
     {
         $result = $this->query($path, $useXpath);
-        if ($result->count() === 0) {
+        if (! $result->count()) {
             throw new ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s EXISTS',
                 $path
@@ -857,7 +857,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     private function queryContentRegexAssertion($path, $pattern, $useXpath = false): void
     {
         $result = $this->query($path, $useXpath);
-        if ($result->count() === 0) {
+        if (! $result->count()) {
             throw new ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s EXISTS',
                 $path
@@ -921,7 +921,7 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
     private function notQueryContentRegexAssertion($path, $pattern, $useXpath = false): void
     {
         $result = $this->query($path, $useXpath);
-        if ($result->count() === 0) {
+        if (! $result->count()) {
             throw new ExpectationFailedException($this->createFailureMessage(sprintf(
                 'Failed asserting node DENOTED BY %s EXISTS',
                 $path


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no


Because some boolean conditions needed to be improved.
There were relative assertion methods to use.
